### PR TITLE
feat: Filialleiter-Rolle einschraenken - branch_berlin@audit.de sieht…

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ flutter run -d chrome
 | admin@audit.de | admin123 | Administrator |
 | auditor@audit.de | auditor123 | Pruefer / Revision |
 | preparer@audit.de | preparer123 | Vorbereitende Person |
-| department@audit.de | department123 | Abteilungsleitung |
-| branch@audit.hr | branch123 | Filialleitung |
-| district@audit.de | district123 | Bezirksleitung |
+| branch_berlin@audit.hr | branch123 | Filialleitung | -> 1 Filiale
+| department@audit.de | department123 | Abteilungsleitung | -> 1 Land
+| district@audit.de | district123 | Bezirksleitung | -> alle Länder
 
 ---
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -20,6 +20,7 @@ class UserBase(BaseModel):
     role: UserRole
     language: str = "de"
     country_code: str = "DE"
+    branch_id: Optional[str] = None
 
 
 class UserCreate(UserBase):

--- a/backend/app/routers/audits.py
+++ b/backend/app/routers/audits.py
@@ -40,6 +40,13 @@ async def list_audits(user: dict = Depends(get_current_user)):
     if user["role"] in _VIEWER_ROLES:
         query = query.where("status", "==", "released")
 
+    # Branch managers only see audits for their own branch
+    user_branch_id = None
+    if user["role"] == "branch_manager":
+        user_doc = db.collection("users").document(user["id"]).get()
+        if user_doc.exists:
+            user_branch_id = user_doc.to_dict().get("branch_id")
+
     docs = query.stream()
 
     audits = []  # type: List[AuditOut]
@@ -48,6 +55,9 @@ async def list_audits(user: dict = Depends(get_current_user)):
         data["id"] = doc.id
         # Viewer roles must not see Nachrevisionen
         if user["role"] in _VIEWER_ROLES and data.get("is_nachrevision"):
+            continue
+        # Branch managers only see their own branch
+        if user_branch_id and data.get("branch_id") != user_branch_id:
             continue
         audits.append(AuditOut(**data))
     audits.sort(key=lambda a: a.created_at, reverse=True)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -42,6 +42,7 @@ async def login(body: LoginRequest):
             role=user_data.get("role", "auditor"),
             language=user_data.get("language", "de"),
             country_code=user_data.get("country_code", "DE"),
+            branch_id=user_data.get("branch_id"),
         ),
     )
 
@@ -68,6 +69,7 @@ async def get_me(user: dict = Depends(get_current_user)):
         role=data.get("role", "auditor"),
         language=data.get("language", "de"),
         country_code=data.get("country_code", "DE"),
+        branch_id=data.get("branch_id"),
     )
 
 

--- a/backend/seed_catalog.py
+++ b/backend/seed_catalog.py
@@ -513,6 +513,7 @@ BRANCHES = [
         "name": "Filiale Berlin Mitte",
         "country_code": "DE",
         "address": "Friedrichstr. 100, 10117 Berlin",
+        "manager_email": "branch_berlin@audit.de",
     },
     {
         "id": "branch-munich",
@@ -557,10 +558,25 @@ def seed():
     cat_ref.update({"question_count": len(QUESTIONS)})
     print("\n  {} new questions added (total {}).".format(q_count, len(QUESTIONS)))
 
-    # --- 3. Create branches ---
+    # --- 3. Create branches and assign manager ---
     for b in BRANCHES:
         b_ref = db.collection("branches").document(b["id"])
+        manager_email = b.pop("manager_email", None)
+        # Look up manager user and link both ways
+        manager_id = None
+        if manager_email:
+            mgr_docs = db.collection("users").where("email", "==", manager_email).limit(1).stream()
+            mgr_doc = next(mgr_docs, None)
+            if mgr_doc:
+                manager_id = mgr_doc.id
+                b["manager_id"] = manager_id
+                # Assign branch_id to the manager user
+                mgr_doc.reference.update({"branch_id": b["id"]})
+                print("  LINK  {} -> {}".format(manager_email, b["id"]))
         if b_ref.get().exists:
+            # Update existing branch with manager_id if needed
+            if manager_id:
+                b_ref.update({"manager_id": manager_id})
             print("  SKIP  Branch '{}' (exists)".format(b["name"]))
         else:
             b_ref.set(b)

--- a/backend/seed_users.py
+++ b/backend/seed_users.py
@@ -46,7 +46,6 @@ DEMO_USERS = [
         "role": "branch_manager",
         "language": "de",
         "country_code": "DE",
-        "branch_id": "branch-berlin",
     },
     {
         "name": "Peter Bezirksleiter",

--- a/backend/seed_users.py
+++ b/backend/seed_users.py
@@ -40,12 +40,13 @@ DEMO_USERS = [
         "country_code": "DE",
     },
     {
-        "name": "Ana Filialleiter",
-        "email": "branch@audit.hr",
+        "name": "Anna Filialleiter",
+        "email": "branch_berlin@audit.de",
         "password": "branch123",
         "role": "branch_manager",
-        "language": "hr",
-        "country_code": "HR",
+        "language": "de",
+        "country_code": "DE",
+        "branch_id": "branch-berlin",
     },
     {
         "name": "Peter Bezirksleiter",

--- a/lib/features/audit/presentation/screens/dashboard_screen.dart
+++ b/lib/features/audit/presentation/screens/dashboard_screen.dart
@@ -37,7 +37,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
         actions: [
           BlocBuilder<SettingsCubit, SettingsState>(
             builder: (context, settings) {
-              const reportRoles = {'department_head', 'branch_manager', 'district_manager'};
+              const reportRoles = {'department_head', 'district_manager'};
               if (reportRoles.contains(settings.userRole)) {
                 return IconButton(
                   icon: const Icon(Icons.bar_chart),


### PR DESCRIPTION
… nur eigene Filiale

- Seed: branch@audit.hr -> branch_berlin@audit.de mit branch_id
- Backend: branch_id zum User-Model hinzugefuegt
- Backend: branch_manager sieht nur Audits seiner Filiale
- Backend: branch_id in Login und /me Response
- Flutter: Reporting-Icon fuer branch_manager entfernt